### PR TITLE
#23 not compleatly fixed, but good enought for dev

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,5 +1,4 @@
 *{
-    box-sizing: border-box;
     font-family: 'Space Mono', monospace;
 }
 
@@ -78,7 +77,6 @@ header {
     position:absolute;
     left:50%;
     bottom:45%;
-    transform: translateX(-50%);
     background-color: white;
     width:1.8vw;
     height:1.8vw;

--- a/js/main.js
+++ b/js/main.js
@@ -234,7 +234,7 @@ function gameLoop() {
             Wenn directionUp = false :  Pongbar bewegt sich nach UNTEN
         */
         const speed = 12;
-        const pos = parseInt(pongbar.style.top);
+        let pos = parseInt(pongbar.style.top);
 
         if (directionUp) {
             pos -= speed;

--- a/js/main.js
+++ b/js/main.js
@@ -24,22 +24,26 @@ let ball = {
 }
 
 function ballLogic(frametime) {
-    if (ball.position.left >= spielfeld.offsetWidth - ball.object.offsetWidth) {
+    // tolerance = the max amount of pixel a ball can move each iteration + 1 for safty
+    const tolerance = ball.speed * frametime + 1;
+    // border around the gamefield
+    const spielfeldBorder = 8;
+    if (ball.position.left + tolerance >= spielfeld.offsetWidth  - ball.object.offsetWidth) {
         //touches the right border
         let newAngle = getAngle( -getDirection(ball.position.angle).x,getDirection(ball.position.angle).y)
         moveBall(newAngle, frametime);
         return;
-    } else if (ball.position.left <= ball.object.offsetWidth) {
+    } else if (ball.position.left <= 0 + tolerance) {
         //touches the left border
         let newAngle = getAngle( -getDirection(ball.position.angle).x,getDirection(ball.position.angle).y)
         moveBall(newAngle, frametime);
         return;
-    } else if (ball.position.bottom >= spielfeld.offsetHeight - ball.object.offsetHeight) {
+    } else if (ball.position.bottom + ball.object.offsetHeight + tolerance >= spielfeld.offsetHeight - spielfeldBorder) {
         //touches the top border
         let newAngle = getAngle(getDirection(ball.position.angle).x,-getDirection(ball.position.angle).y)
         moveBall(newAngle, frametime);
         return;
-    } else if (ball.position.bottom <= 0) {
+    } else if (ball.position.bottom <= 0 + tolerance) {
         //touches the bottom border
         let newAngle = getAngle(getDirection(ball.position.angle).x,-getDirection(ball.position.angle).y)
         moveBall(newAngle, frametime);
@@ -58,8 +62,8 @@ function moveBall(angle, frametime) {
         bottom: ball.position.bottom + (getDirection(angle).y * ball.speed * frametime),
         angle: angle,
     }
-    ball.object.style.bottom = "" + newBallPosition.bottom;
-    ball.object.style.left = "" + newBallPosition.left;
+    ball.object.style.bottom = "" + Math.round(newBallPosition.bottom);
+    ball.object.style.left = "" + Math.round(newBallPosition.left);
 
     saveBallValues(newBallPosition.left, newBallPosition.bottom, newBallPosition.angle);
     


### PR DESCRIPTION
Bei der Bewegungs-Berechnung kann folgendes Problem auftreten:

Rein rechnerisch bewegt sich der Ball mindestens 0 und maximal (ball.speed * iterationszeit|gametime).
Beispiel: 0 ~1 * 500 (ball.speed) * 0.005 (iterationszeit|gametime) => ein Ergebnis zwischen 0 ~ 2,5

Falls sich nun ein Ball kurz vor der Wand befindet, beispielsweise 1px. Und er sich dann 2.5px bewegen soll, weil die Bewegung so groß ist. Dann befindet er sich nach der Bewegung 1,5px in der Wand.
-> Das ist das Problem.

Nun hab ich die Konstante `tolerance` erstellt. Diese ist immer die maximale Bewegungsweite, die der Ball zurücksetzen kann. Der Berührungspunkt / Richtungswechsel-Punkt an der Wand wird um den Wert `tolerance` nach innen verschoben. Um den Fall von oben vorzubeugen. Um Ihn ganz zu eliminieren habe ich dem Wert 1 Pixel zusätzlich gegeben.

Ein Auswirkung auf meine Lösung ist: Je größer die Ballgeschwindigkeit, desto größer wird `tolerance`.

Der Problemfall tritt nun noch sehr selten auf. So selten, dass ich vorschlage den Bugfix im Hinterkopf zu behalten, aber erst in der späteren Entwicklung noch einmal zu betrachten.
Ich habe mit der Lösung also die Fehlerwahrscheinlichkeit verringert.