### PR TITLE
So in etwa müsste das aussehen

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,5 +26,6 @@
         </div>
     </main>
 
-    <script language="javascript" type="text/javascript" src="js/main.js"></script>
+    <script language="javascript" type="text/javascript" src="js/calc.js"></script>
+    <script language="javascript" type="text/javascript" src="js/dom.js"></script>
 </body>

--- a/js/calc.js
+++ b/js/calc.js
@@ -1,0 +1,91 @@
+function getDirection(directAngle) {
+    //Umrechnung von einem Winkel in den dazugehörigen Vektor
+    let x;
+    let y;
+    if (directAngle > 360) {
+        directAngle = directAngle - 360;
+    }
+    if (directAngle < 0) {
+        directAngle = 360 + directAngle;
+    }
+    let angle = (Math.PI / 180) * directAngle;
+
+    if (directAngle <= 90) {
+        let xa = Math.sin(angle);
+        let ya = Math.cos(angle);
+
+        x = xa / (xa + ya);
+        y = ya / (xa + ya);
+    } else if (directAngle <= 180) {
+        let xa = Math.sin(angle);
+        let ya = Math.cos(angle);
+
+        x = xa / (xa + Math.abs(ya));
+        y = ya / (xa + Math.abs(ya));
+    } else if (directAngle <= 270) {
+        let xa = Math.sin(angle);
+        let ya = Math.cos(angle);
+
+        x = xa / Math.abs(xa + ya);
+        y = ya / Math.abs(xa + ya);
+    } else if (directAngle <= 360) {
+        let xa = Math.sin(angle);
+        let ya = Math.cos(angle);
+
+        x = xa / (Math.abs(xa) + ya);
+        y = ya / (Math.abs(xa) + ya);
+    }
+    return {
+        x: round(x),
+        y: round(y),
+    }
+}
+
+function getAngle(x, y) {
+    //Umrechnung von einem Vektor in den dazugehörigen Winkel
+    if ((x === 0 && y === 0) || (x === 1 && y === 1)) {
+        //keine Bewegung === keine Richung
+        return;
+    }
+    //wir können nicht durch 0 teilen, aber durch annähernd 0
+    if (y === 0) {
+        y = 0.00000001;
+    }
+    if (x === 0) {
+        x = 0.00000001;
+    }
+
+    let alpha = Math.round((180 / Math.PI) * Math.atan(x / y));
+    let angle;
+
+    //arctan hat nur einen Ergebnisbereich von 0 - 90° -> es müssen noch Anpassungen unternommen werden
+    if (x > 0 && y > 0) {
+        angle = alpha;
+    } else if (y < 0) {
+        angle = alpha + 180;
+    } else if (x < 0) {
+        angle = alpha + 360;
+    }
+
+    return angle;
+}
+
+function round(n) {
+    // 2 decimal places
+    let number = (Math.round(n * 100) / 100)
+    return number;
+}
+
+if (module !== undefined) {
+    module.exports = {
+        getDirection,
+        getAngle,
+        round
+    }
+}
+
+if (window) {
+    window.getDirection = getDirection
+    window.getAngle = getAngle
+    window.round = round 
+}

--- a/js/calc.test.js
+++ b/js/calc.test.js
@@ -1,6 +1,4 @@
-const getDirection = require('./main.js').getDirection;
-const round = require('./main.js').round;
-const getAngle = require('./main.js').getAngle;
+const {getDirection, round, getAngle } = require('./calc.js');
 
 describe("function: getDirection", () => {
     [{

--- a/js/dom.js
+++ b/js/dom.js
@@ -1,8 +1,4 @@
-module.exports = {
-    getDirection: getDirection,
-    getAngle: getAngle,
-    round: round
-}
+
 
 let frametimeBefore = Date.now();
 let frametime; // in ms
@@ -78,83 +74,6 @@ function moveBall(angle, frametime) {
 
 }
 
-function getDirection(directAngle) {
-    //Umrechnung von einem Winkel in den dazugehörigen Vektor
-    let x;
-    let y;
-    if (directAngle > 360) {
-        directAngle = directAngle - 360;
-    }
-    if (directAngle < 0) {
-        directAngle = 360 + directAngle;
-    }
-    let angle = (Math.PI / 180) * directAngle;
-
-    if (directAngle <= 90) {
-        let xa = Math.sin(angle);
-        let ya = Math.cos(angle);
-
-        x = xa / (xa + ya);
-        y = ya / (xa + ya);
-    } else if (directAngle <= 180) {
-        let xa = Math.sin(angle);
-        let ya = Math.cos(angle);
-
-        x = xa / (xa + Math.abs(ya));
-        y = ya / (xa + Math.abs(ya));
-    } else if (directAngle <= 270) {
-        let xa = Math.sin(angle);
-        let ya = Math.cos(angle);
-
-        x = xa / Math.abs(xa + ya);
-        y = ya / Math.abs(xa + ya);
-    } else if (directAngle <= 360) {
-        let xa = Math.sin(angle);
-        let ya = Math.cos(angle);
-
-        x = xa / (Math.abs(xa) + ya);
-        y = ya / (Math.abs(xa) + ya);
-    }
-    return {
-        x: round(x),
-        y: round(y),
-    }
-}
-
-function getAngle(x, y) {
-    //Umrechnung von einem Vektor in den dazugehörigen Winkel
-    if ((x === 0 && y === 0) || (x === 1 && y === 1)) {
-        //keine Bewegung === keine Richung
-        return;
-    }
-    //wir können nicht durch 0 teilen, aber durch annähernd 0
-    if (y === 0) {
-        y = 0.00000001;
-    }
-    if (x === 0) {
-        x = 0.00000001;
-    }
-
-    let alpha = Math.round((180 / Math.PI) * Math.atan(x / y));
-    let angle;
-
-    //arctan hat nur einen Ergebnisbereich von 0 - 90° -> es müssen noch Anpassungen unternommen werden
-    if (x > 0 && y > 0) {
-        angle = alpha;
-    } else if (y < 0) {
-        angle = alpha + 180;
-    } else if (x < 0) {
-        angle = alpha + 360;
-    }
-
-    return angle;
-}
-
-function round(n) {
-    // 2 decimal places
-    let number = (Math.round(n * 100) / 100)
-    return number;
-}
 
 function saveBallValues(left, bottom, angle) {
     ball.position.left = left;

--- a/js/dom.test.js
+++ b/js/dom.test.js
@@ -1,5 +1,3 @@
-const { JSDOM,VirtualConsole} = require('jsdom')
-
 describe('DOM Tests', () => {
     let dom
     let document
@@ -10,7 +8,7 @@ describe('DOM Tests', () => {
         document = dom.window.document
     })
 
-    test(`if spielfeld exists`, () => {
+    it(`if spielfeld exists`, () => {
         const spielfeld = document.getElementById("spielfeld");
         expect(spielfeld).toBeDefined();
     })

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "jsdom": "^15.2.1"
   },
   "scripts": {
-    "test": "jest"
+    "start": "ws",
+    "test": "jest",
+    "tdd": "jest --watch"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hallo Markus,

also hier mal wie ich mir das in etwa vorstelle. Allerdings sind die pads verschwunden. Das war aber in Deiner Version auch schon der Fall.

Aber so kann man main.js in zwei Dateien calc.js und dom.js aufteilen und beide separat testen.

Dieser Code am ende von calc:
if (window) {...}

if (module) {...}

ist Code den man schreiben muss, wenn man will, dass die eigenen Funktionen im Browser als auch im Node laufen. 

Das könnte man ich evtl sparen, wenn man sich mit einem Build-Tool wie WebPack auseinander setzen würde.

Kuck bitte auch nochmal über die checkKeys-Funktionen, die könnte man soviel verständlicher und einfacher noch schreiben. Warum handelt ihr die key-Downevents nicht direkt und spart Euch diese Weiterleitung über checkPassedKeys? 

Übrigens das document, dass eigentlich hätte Fehlen müssen, kommt wohl aus Jest selbst, um JavaScript-gebaute Komponenten dort direkt abzulegen. 

Bis dann
Christian